### PR TITLE
merge: hotfix ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ ${CSV_PATH}: ${INSTALL_DIR}/index/${OUTPUT_NAME}.json
 	${UV} python -m fdua_competition.main -o ${OUTPUT_NAME} -m ${MODE}
 	@echo "done"
 
-vectorstore: ${INSTALL_DIR}/vectorstore/chroma/${OUTPUT_NAME}/.success
-${INSTALL_DIR}/vectorstore/chroma/${OUTPUT_NAME}/.success: ${INSTALL_DIR}/.installed
+vectorstore: ${INSTALL_DIR}/vectorstores/chroma/${OUTPUT_NAME}/.success
+${INSTALL_DIR}/vectorstores/chroma/${OUTPUT_NAME}/.success: ${INSTALL_DIR}/.installed
 	@echo "\npreparing vectorstore..."
 	${UV} python -m fdua_competition.vectorstore -o ${OUTPUT_NAME}
-	touch ${INSTALL_DIR}/vectorstore/chroma/${OUTPUT_NAME}/.success
+	touch ${INSTALL_DIR}/vectorstores/chroma/${OUTPUT_NAME}/.success
 	@echo "done"
 
 index: ${INSTALL_DIR}/index/${OUTPUT_NAME}.json

--- a/fdua_competition/pdf_handler.py
+++ b/fdua_competition/pdf_handler.py
@@ -29,8 +29,8 @@ def load_documents(mode: Mode = Mode.TEST) -> list[Document]:
 
 def split_document(doc: Document) -> list[Document]:
     splitter = RecursiveCharacterTextSplitter(
-        chunk_size=800,
-        chunk_overlap=200,
+        chunk_size=1000,
+        chunk_overlap=150,
         separators=["\n\n", "\n", "。", "．", "？", "！", "「", "」", "【", "】"],
     )
     split_doc = splitter.split_text(doc.page_content)


### PR DESCRIPTION
This pull request includes changes to the `Makefile` and `fdua_competition/pdf_handler.py` to update directory paths and document splitting parameters, respectively.

Directory path updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L31-R35): Changed the directory path for vectorstores from `vectorstore` to `vectorstores` to ensure consistency.

Document splitting parameter adjustments:

* [`fdua_competition/pdf_handler.py`](diffhunk://#diff-637e3957e74bcebe9273a22c6a19ae9949607e6086fbbdb5788bb58dbbc77fefL32-R33): Increased `chunk_size` from 800 to 1000 and decreased `chunk_overlap` from 200 to 150 in the `split_document` function to optimize document splitting.